### PR TITLE
fix dns behind traefik proxy

### DIFF
--- a/pihole/docker-compose.yml
+++ b/pihole/docker-compose.yml
@@ -5,9 +5,10 @@ services:
   pihole:
     image: pihole/pihole:2021.10
     environment:
-      - RATE_LIMIT=0/0
       - TZ=America/New_York
       - WEBPASSWORD_FILE=/run/secrets/pihole-web-password
+      # This must be set in /etc/pihole/pihole-FTL.conf once created.
+      # - RATE_LIMIT=0/0
     secrets:
       - pihole-web-password
     volumes:


### PR DESCRIPTION
Doesn't seem to be any way to forward client details for dns requests (like `XFF` headers etc). 

Also couldn't find a way to have traefik service 80/http, but allow 53 to work on the host network. This is probably possible.

For now, just disable pi-hole's rate limiting (or rather note how to do that since it can't be controlled via docker `environment` variables.

closes #41 