### PR TITLE
Revert "Update traefik Docker tag to v2.8.5"

### DIFF
--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   traefik:
-    image: traefik:v2.8.5
+    image: traefik:v2.8.4
     ports:
 #      - 53:53/tcp
 #      - 53:53/udp


### PR DESCRIPTION
Reverts jeremyhayes/pi-cluster#175


No x86 image published?
https://hub.docker.com/layers/library/traefik/v2.8.5/images/sha256-643f60f24294106bfe36e7b1c78031ecfd0bfd94565de3bdf04a36c3fa7cddb7?context=explore