### PR TITLE
Revert "Update grafana/grafana Docker tag to v10.2.3"

### DIFF
--- a/grafana/docker-compose.yml
+++ b/grafana/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   grafana:
-    image: grafana/grafana:10.2.3
+    image: grafana/grafana:10.2.2
     volumes:
       - grafana-data:/var/lib/grafana
     configs:


### PR DESCRIPTION
This reverts commit 329b3ce7013990d52703a2430ba647fce3cbe60f.

Auto scaling on both Gauge and Bar panels broken in 10.2.3.